### PR TITLE
Release 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>comics</groupId>
     <artifactId>jcomicsutils</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>comics</groupId>
     <artifactId>jcomicsutils</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/comics/commands/FileValidator.java
+++ b/src/main/java/comics/commands/FileValidator.java
@@ -1,0 +1,9 @@
+package comics.commands;
+
+import java.io.File;
+
+public interface FileValidator {
+
+    void readFile(File file);
+    void validate() throws Exception;
+}

--- a/src/main/java/comics/commands/PackCommand.java
+++ b/src/main/java/comics/commands/PackCommand.java
@@ -23,12 +23,20 @@ public class PackCommand {
     public Boolean disableProgressBar = false;
     public void setDisableProgressBar(Boolean disable) { disableProgressBar = disable; }
 
+    @Parameter(
+        name="gc",
+        longName="garbage-collector",
+        description="If set, it will attempt to remove images that do not belong to the comic"
+    )
+    public Boolean garbageCollector = false;
+    public void setGarbageCollector(Boolean gc) { garbageCollector = gc; }
+
     @Run
     public int run(Path cwd) throws Exception {
         commonChecks(disableProgressBar);
         return new GenericFileListOperation(cwd, "Packing comics...").execute(
             File::isDirectory,
-            dir -> new CompressionService().compressComic(dir, all ? null : DEFAULT_FILE_EXCLUSIONS),
+            dir -> new CompressionService().compressComic(dir, garbageCollector, all ? null : DEFAULT_FILE_EXCLUSIONS),
             new RepeatedNamesValidator()
         );
     }

--- a/src/main/java/comics/commands/PackCommand.java
+++ b/src/main/java/comics/commands/PackCommand.java
@@ -9,12 +9,11 @@ import comics.logic.RepeatedNamesValidator;
 import java.io.File;
 import java.nio.file.Path;
 
+import static comics.logic.CompressionService.DEFAULT_FILE_EXCLUSIONS;
 import static comics.utils.Utils.commonChecks;
 
 @Command(command="pack", description="Packs every sub-directory under CWD into a .cbz file")
 public class PackCommand {
-
-    public static final String[] DEFAULT_EXCLUSIONS = new String[] { "txt", "xml", "db", "nfo" };
 
     @Parameter(name="a", longName="all", description="If set, the command will include non-image files in the comics")
     public Boolean all = false;
@@ -29,7 +28,7 @@ public class PackCommand {
         commonChecks(disableProgressBar);
         return new GenericFileListOperation(cwd, "Packing comics...").execute(
             File::isDirectory,
-            dir -> new CompressionService().compressComic(dir, all ? null : DEFAULT_EXCLUSIONS),
+            dir -> new CompressionService().compressComic(dir, all ? null : DEFAULT_FILE_EXCLUSIONS),
             new RepeatedNamesValidator()
         );
     }

--- a/src/main/java/comics/commands/PackCommand.java
+++ b/src/main/java/comics/commands/PackCommand.java
@@ -14,7 +14,7 @@ import static comics.utils.Utils.commonChecks;
 @Command(command="pack", description="Packs every sub-directory under CWD into a .cbz file")
 public class PackCommand {
 
-    static final String[] DEFAULT_EXCLUSIONS = new String[] { "txt", "xml", "db" };
+    public static final String[] DEFAULT_EXCLUSIONS = new String[] { "txt", "xml", "db", "nfo" };
 
     @Parameter(name="a", longName="all", description="If set, the command will include non-image files in the comics")
     public Boolean all = false;

--- a/src/main/java/comics/commands/PackCommand.java
+++ b/src/main/java/comics/commands/PackCommand.java
@@ -4,6 +4,7 @@ import cli.annotations.Command;
 import cli.annotations.Parameter;
 import cli.annotations.Run;
 import comics.logic.CompressionService;
+import comics.logic.RepeatedNamesValidator;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -28,7 +29,8 @@ public class PackCommand {
         commonChecks(disableProgressBar);
         return new GenericFileListOperation(cwd, "Packing comics...").execute(
             File::isDirectory,
-            dir -> new CompressionService().compressComic(dir, all ? null : DEFAULT_EXCLUSIONS)
+            dir -> new CompressionService().compressComic(dir, all ? null : DEFAULT_EXCLUSIONS),
+            new RepeatedNamesValidator()
         );
     }
 }

--- a/src/main/java/comics/commands/Pdf2CbzCommand.java
+++ b/src/main/java/comics/commands/Pdf2CbzCommand.java
@@ -8,7 +8,7 @@ import comics.logic.PdfService;
 
 import java.nio.file.Path;
 
-import static comics.commands.PackCommand.DEFAULT_EXCLUSIONS;
+import static comics.logic.CompressionService.DEFAULT_FILE_EXCLUSIONS;
 import static comics.utils.Utils.commonChecks;
 
 @Command(
@@ -36,7 +36,7 @@ public class Pdf2CbzCommand {
             f -> !f.isDirectory() && (f.getName().toLowerCase().endsWith("pdf")),
             f -> {
                 var directory = new PdfService().convertPDF(f, format);
-                new CompressionService().compressComic(directory, DEFAULT_EXCLUSIONS);
+                new CompressionService().compressComic(directory, DEFAULT_FILE_EXCLUSIONS);
             }
         );
     }

--- a/src/main/java/comics/commands/Pdf2CbzCommand.java
+++ b/src/main/java/comics/commands/Pdf2CbzCommand.java
@@ -30,7 +30,7 @@ public class Pdf2CbzCommand {
     public void setDisableProgressBar(Boolean disable) { disableProgressBar = disable; }
 
     @Run
-    public int execute(Path cwd) throws Exception {
+    public int run(Path cwd) throws Exception {
         commonChecks(disableProgressBar);
         return new GenericFileListOperation(cwd, "Converting pdf files...").execute(
             f -> !f.isDirectory() && (f.getName().toLowerCase().endsWith("pdf")),

--- a/src/main/java/comics/commands/Pdf2CbzCommand.java
+++ b/src/main/java/comics/commands/Pdf2CbzCommand.java
@@ -36,7 +36,7 @@ public class Pdf2CbzCommand {
             f -> !f.isDirectory() && (f.getName().toLowerCase().endsWith("pdf")),
             f -> {
                 var directory = new PdfService().convertPDF(f, format);
-                new CompressionService().compressComic(directory, DEFAULT_FILE_EXCLUSIONS);
+                new CompressionService().compressComic(directory, false, DEFAULT_FILE_EXCLUSIONS);
             }
         );
     }

--- a/src/main/java/comics/commands/RepackCommand.java
+++ b/src/main/java/comics/commands/RepackCommand.java
@@ -23,6 +23,14 @@ public class RepackCommand {
     public Boolean disableProgressBar = false;
     public void setDisableProgressBar(Boolean disable) { disableProgressBar = disable; }
 
+    @Parameter(
+        name="gc",
+        longName="garbage-collector",
+        description="If set, it will attempt to remove images that do not belong to the comic"
+    )
+    public Boolean garbageCollector = false;
+    public void setGarbageCollector(Boolean gc) { garbageCollector = gc; }
+
     @Run
     public int run(Path cwd) throws Exception {
         commonChecks(disableProgressBar);
@@ -35,7 +43,7 @@ public class RepackCommand {
                 );
                 var compressionService = new CompressionService();
                 compressionService.decompressComic(f);
-                compressionService.compressComic(expectedDirectory, all ? null : DEFAULT_FILE_EXCLUSIONS);
+                compressionService.compressComic(expectedDirectory, garbageCollector, all ? null : DEFAULT_FILE_EXCLUSIONS);
             },
             new RepeatedNamesValidator()
         );

--- a/src/main/java/comics/commands/RepackCommand.java
+++ b/src/main/java/comics/commands/RepackCommand.java
@@ -5,12 +5,11 @@ import cli.annotations.Parameter;
 import cli.annotations.Run;
 import comics.logic.CompressionService;
 import comics.logic.RepeatedNamesValidator;
-import org.apache.pdfbox.contentstream.operator.graphics.CurveToReplicateFinalPoint;
 
 import java.io.File;
 import java.nio.file.Path;
 
-import static comics.commands.PackCommand.DEFAULT_EXCLUSIONS;
+import static comics.logic.CompressionService.DEFAULT_FILE_EXCLUSIONS;
 import static comics.utils.Utils.commonChecks;
 
 @Command(command = "repack", description = "Unpacks every cbz/cbr file under CWD and repacks them into .cbz files")
@@ -36,7 +35,7 @@ public class RepackCommand {
                 );
                 var compressionService = new CompressionService();
                 compressionService.decompressComic(f);
-                compressionService.compressComic(expectedDirectory, all ? null : DEFAULT_EXCLUSIONS);
+                compressionService.compressComic(expectedDirectory, all ? null : DEFAULT_FILE_EXCLUSIONS);
             },
             new RepeatedNamesValidator()
         );

--- a/src/main/java/comics/commands/RepackCommand.java
+++ b/src/main/java/comics/commands/RepackCommand.java
@@ -4,6 +4,8 @@ import cli.annotations.Command;
 import cli.annotations.Parameter;
 import cli.annotations.Run;
 import comics.logic.CompressionService;
+import comics.logic.RepeatedNamesValidator;
+import org.apache.pdfbox.contentstream.operator.graphics.CurveToReplicateFinalPoint;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -23,7 +25,7 @@ public class RepackCommand {
     public void setDisableProgressBar(Boolean disable) { disableProgressBar = disable; }
 
     @Run
-    public int execute(Path cwd) throws Exception {
+    public int run(Path cwd) throws Exception {
         commonChecks(disableProgressBar);
         return new GenericFileListOperation(cwd, "Repacking comics...").execute(
             f -> !f.isDirectory() && (f.getName().toLowerCase().endsWith("cbz") || f.getName().toLowerCase().endsWith("cbr")),
@@ -35,7 +37,8 @@ public class RepackCommand {
                 var compressionService = new CompressionService();
                 compressionService.decompressComic(f);
                 compressionService.compressComic(expectedDirectory, all ? null : DEFAULT_EXCLUSIONS);
-            }
+            },
+            new RepeatedNamesValidator()
         );
     }
 }

--- a/src/main/java/comics/logic/CompressionService.java
+++ b/src/main/java/comics/logic/CompressionService.java
@@ -11,6 +11,9 @@ import java.nio.file.Files;
 
 public class CompressionService {
 
+    public static final String[] DEFAULT_FILE_EXCLUSIONS = new String[] { "txt", "xml", "db", "nfo" };
+    static final String[] DEFAULT_DIRECTORY_EXCLUSIONS = new String[] { "__MACOSX" };
+
     public CompressionService() { }
 
     // 7z is in the path and accessible
@@ -85,8 +88,9 @@ public class CompressionService {
                 cwd(directory).
                 command("7z").
                 parameter("a").
-                parameter("-tzip").
-                parameter("-xr!__MACOSX");
+                parameter("-tzip");
+            for (String dir: DEFAULT_DIRECTORY_EXCLUSIONS)
+                builder.parameter("-xr!" + dir);
             if (exclusions != null)
                 for (var exclusion: exclusions) builder.parameter("-xr!*." + exclusion);
             var result = builder.parameter(targetFile.getAbsolutePath()).

--- a/src/main/java/comics/logic/CompressionService.java
+++ b/src/main/java/comics/logic/CompressionService.java
@@ -80,11 +80,13 @@ public class CompressionService {
                 directory.getParentFile(),
                 new NameConverter().normalizeFileName(directory.getName() + ".cbz")
             );
+
             var builder = ShellCommandLauncher.builder().
                 cwd(directory).
                 command("7z").
                 parameter("a").
-                parameter("-tzip");
+                parameter("-tzip").
+                parameter("-xr!__MACOSX");
             if (exclusions != null)
                 for (var exclusion: exclusions) builder.parameter("-xr!*." + exclusion);
             var result = builder.parameter(targetFile.getAbsolutePath()).

--- a/src/main/java/comics/logic/RepeatedNamesValidator.java
+++ b/src/main/java/comics/logic/RepeatedNamesValidator.java
@@ -1,0 +1,43 @@
+package comics.logic;
+
+import comics.commands.FileValidator;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+// Will be executed by the generic file list operation in order to detect possible repetitions of file names after normalization
+public class RepeatedNamesValidator implements FileValidator {
+
+    private final List<File> files;
+
+    public RepeatedNamesValidator() {
+        files = new LinkedList<>();
+    }
+
+    @Override
+    public void readFile(File file) {
+        files.add(file);
+    }
+
+    @Override
+    public void validate() throws Exception {
+        var converter = new NameConverter();
+        var normalizedNames = files.stream().map(
+            f -> converter.normalizeFileName(f.getName())
+        ).toList();
+        var repeatedNormalizedFileNames = normalizedNames.stream().filter(
+            normalizedName -> Collections.frequency(normalizedNames, normalizedName) > 1
+        ).collect(Collectors.toSet());
+        if (!repeatedNormalizedFileNames.isEmpty()) {
+            throw new Exception(
+                String.format(
+                    "The following files have a naming conflict:%n%s",
+                    String.join(System.lineSeparator(), repeatedNormalizedFileNames.stream().toList())
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/comics/logic/TestFilenameValidator.java
+++ b/src/test/java/comics/logic/TestFilenameValidator.java
@@ -1,0 +1,45 @@
+package comics.logic;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static comics.utils.Tools.sandbox;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestFilenameValidator {
+
+    @Test
+    public void testDirectoriesNoRepetition() {
+        var sb = sandbox();
+        sb.runTest((File sandbox) -> {
+            var directories = List.of("dir1", "dir2", "dir 3");
+            directories.forEach(d -> sb.copyResource("/uncompressed/up.jpg", d + "/up.jpg"));
+            var validator = new RepeatedNamesValidator();
+            directories.forEach(d -> validator.readFile(new File(sandbox, d)));
+            try {
+                validator.validate();
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    public void testDirectoriesWithRepetition() {
+        var sb = sandbox();
+        sb.runTest((File sandbox) -> {
+            var directories = List.of("dir 1", "dir 2", "dir 1 [by some guy]");
+            directories.forEach(d -> sb.copyResource("/uncompressed/up.jpg", d + "/up.jpg"));
+            var validator = new RepeatedNamesValidator();
+            directories.forEach(d -> validator.readFile(new File(sandbox, d)));
+            assertThrows(
+                Exception.class,
+                validator::validate,
+                String.format("The following files have a naming conflict:%nDir - 1")
+            );
+        });
+    }
+}

--- a/src/test/java/comics/logic/TestPack.java
+++ b/src/test/java/comics/logic/TestPack.java
@@ -232,9 +232,10 @@ public class TestPack {
             unpackCommand.setDisableProgressBar(true);
             unpackCommand.run(sandbox.toPath());
 
-            assertTrue(baseDir.exists());
-            assertTrue(new File(baseDir, "up.jpg").exists());
-            assertFalse(undesiredDir.exists());
+            var newBaseDir = new File(sandbox, "Comic");
+            assertTrue(newBaseDir.exists());
+            assertTrue(new File(newBaseDir, "up.jpg").exists());
+            assertFalse(new File(newBaseDir, "__MACOSX").exists());
         });
     }
 }

--- a/src/test/java/comics/logic/TestPack.java
+++ b/src/test/java/comics/logic/TestPack.java
@@ -119,7 +119,9 @@ public class TestPack {
                 originalData.keySet().stream().filter(s -> !s.endsWith("txt")).toList().size(),
                 emptyIfNull(newChildDirectory.listFiles()).length
             );
-            assertTrue(Arrays.stream(emptyIfNull(newChildDirectory.listFiles())).filter(s -> s.getName().endsWith("txt")).toList().isEmpty());
+            assertTrue(Arrays.stream(emptyIfNull(newChildDirectory.listFiles())).filter(
+                s -> s.getName().endsWith("txt")
+            ).toList().isEmpty());
             for (var f: emptyIfNull(newChildDirectory.listFiles())) {
                 assertEquals(originalData.get(f.getName()), md5(f));
             }

--- a/src/test/java/comics/logic/TestPack.java
+++ b/src/test/java/comics/logic/TestPack.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-import static comics.commands.PackCommand.DEFAULT_EXCLUSIONS;
+import static comics.logic.CompressionService.DEFAULT_FILE_EXCLUSIONS;
 import static comics.utils.Tools.TestLevel.COMMAND;
 import static comics.utils.Tools.TestLevel.SERVICE;
 import static comics.utils.Tools.createNewFile;
@@ -108,7 +108,7 @@ public class TestPack {
             }
             if (level == SERVICE) {
                 var compressionService = new CompressionService();
-                compressionService.compressComic(childDirectory, DEFAULT_EXCLUSIONS);
+                compressionService.compressComic(childDirectory, DEFAULT_FILE_EXCLUSIONS);
             } else if (level == COMMAND) {
                 var packCommand = new PackCommand();
                 packCommand.setDisableProgressBar(true);

--- a/src/test/java/comics/logic/TestPack.java
+++ b/src/test/java/comics/logic/TestPack.java
@@ -178,4 +178,19 @@ public class TestPack {
             }
         });
     }
+
+    @Test
+    public void testPreventRepeatedFiles() {
+        var sb = sandbox();
+        var ctx = sb.runTest((File sandbox) -> {
+            sb.copyResource("/uncompressed/up.jpg", "some directory [by some guy]/up.jpg");
+            sb.copyResource("/uncompressed/up.jpg", "some directory/up.jpg");
+            var packCommand = new PackCommand();
+            packCommand.setDisableProgressBar(true);
+            return packCommand.run(sandbox.toPath());
+        }, true);
+        assertTrue(
+            ctx.err().contains(String.format("The following files have a naming conflict:%nSome Directory"))
+        );
+    }
 }

--- a/src/test/java/comics/logic/TestPack.java
+++ b/src/test/java/comics/logic/TestPack.java
@@ -224,7 +224,7 @@ public class TestPack {
             packCommand.setDisableProgressBar(true);
             packCommand.run(sandbox.toPath());
 
-            assertTrue(new File(sandbox, "comic.cbz").exists());
+            assertTrue(new File(sandbox, "Comic.cbz").exists());
             assertFalse(baseDir.exists());
 
             // Unpack comic

--- a/src/test/java/comics/logic/TestPack.java
+++ b/src/test/java/comics/logic/TestPack.java
@@ -1,6 +1,7 @@
 package comics.logic;
 
 import comics.commands.PackCommand;
+import comics.commands.UnpackCommand;
 import comics.utils.Tools.TestLevel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -205,5 +206,35 @@ public class TestPack {
         assertTrue(
             ctx.err().contains(String.format("The following files have a naming conflict:%nSome Directory"))
         );
+    }
+
+    @Test
+    public void testRemoveUndesiredDirectories() {
+        var sb = sandbox();
+        sb.runTest((File sandbox) -> {
+            var baseDir = new File(sandbox, "comic");
+            mkdir(baseDir);
+            sb.copyResource("/uncompressed/up.jpg", baseDir.getName() + "/up.jpg");
+
+            var undesiredDir = new File(baseDir, "__MACOSX");
+            mkdir(undesiredDir);
+
+            // Compress comic
+            var packCommand = new PackCommand();
+            packCommand.setDisableProgressBar(true);
+            packCommand.run(sandbox.toPath());
+
+            assertTrue(new File(sandbox, "comic.cbz").exists());
+            assertFalse(baseDir.exists());
+
+            // Unpack comic
+            var unpackCommand = new UnpackCommand();
+            unpackCommand.setDisableProgressBar(true);
+            unpackCommand.run(sandbox.toPath());
+
+            assertTrue(baseDir.exists());
+            assertTrue(new File(baseDir, "up.jpg").exists());
+            assertFalse(undesiredDir.exists());
+        });
     }
 }

--- a/src/test/java/comics/logic/TestPack.java
+++ b/src/test/java/comics/logic/TestPack.java
@@ -187,7 +187,11 @@ public class TestPack {
             sb.copyResource("/uncompressed/up.jpg", "some directory/up.jpg");
             var packCommand = new PackCommand();
             packCommand.setDisableProgressBar(true);
-            return packCommand.run(sandbox.toPath());
+            var ret = packCommand.run(sandbox.toPath());
+            // The directories have not been removed
+            assertTrue(new File(sandbox, "some directory [by some guy]").exists());
+            assertTrue(new File(sandbox, "some directory").exists());
+            return ret;
         }, true);
         assertTrue(
             ctx.err().contains(String.format("The following files have a naming conflict:%nSome Directory"))

--- a/src/test/java/comics/logic/TestPack.java
+++ b/src/test/java/comics/logic/TestPack.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import static comics.commands.PackCommand.DEFAULT_EXCLUSIONS;
 import static comics.utils.Tools.TestLevel.COMMAND;
 import static comics.utils.Tools.TestLevel.SERVICE;
 import static comics.utils.Tools.createNewFile;
@@ -43,7 +44,10 @@ public class TestPack {
                 "up.jpg",
                 "right.jpg",
                 "down.jpg",
-                "left.jpg"
+                "left.jpg",
+                "something.nfo",
+                "thumbs.db",
+                "should_not_be_here.xml"
             ).forEach(s -> sb.copyResource("/uncompressed/" + s, childDirectory.getName() + "/" + s));
             // Remember the directory
             var originalData = new HashMap<String, String>();
@@ -91,7 +95,10 @@ public class TestPack {
                 "up.jpg",
                 "right.jpg",
                 "down.jpg",
-                "left.jpg"
+                "left.jpg",
+                "something.nfo",
+                "thumbs.db",
+                "should_not_be_here.xml"
             ).forEach(s -> sb.copyResource("/uncompressed/" + s, childDirectory.getName() + "/" + s));
             // Remember the directory
             var originalData = new HashMap<String, String>();
@@ -100,7 +107,7 @@ public class TestPack {
             }
             if (level == SERVICE) {
                 var compressionService = new CompressionService();
-                compressionService.compressComic(childDirectory, "txt");
+                compressionService.compressComic(childDirectory, DEFAULT_EXCLUSIONS);
             } else if (level == COMMAND) {
                 var packCommand = new PackCommand();
                 packCommand.setDisableProgressBar(true);
@@ -116,11 +123,11 @@ public class TestPack {
             assertFalse(comicFile.exists());
             assertTrue(newChildDirectory.exists());
             assertEquals(
-                originalData.keySet().stream().filter(s -> !s.endsWith("txt")).toList().size(),
+                originalData.keySet().stream().filter(s -> s.endsWith("jpg")).toList().size(),
                 emptyIfNull(newChildDirectory.listFiles()).length
             );
             assertTrue(Arrays.stream(emptyIfNull(newChildDirectory.listFiles())).filter(
-                s -> s.getName().endsWith("txt")
+                s -> !s.getName().endsWith("jpg")
             ).toList().isEmpty());
             for (var f: emptyIfNull(newChildDirectory.listFiles())) {
                 assertEquals(originalData.get(f.getName()), md5(f));

--- a/src/test/java/comics/logic/TestPdf.java
+++ b/src/test/java/comics/logic/TestPdf.java
@@ -78,7 +78,7 @@ public class TestPdf {
             var pdf = sb.copyResource("/compressed/test.pdf", "test.pdf");
             var command = new Pdf2CbzCommand();
             command.setDisableProgressBar(true);
-            var ret = command.execute(sandbox.toPath());
+            var ret = command.run(sandbox.toPath());
             assertEquals(0, ret);
             assertFalse(pdf.exists());
             // We have created a directory as intermediate step that should not be there any more
@@ -103,7 +103,7 @@ public class TestPdf {
             var command = new Pdf2CbzCommand();
             command.setDisableProgressBar(true);
             command.setFormat(format);
-            var ret = command.execute(sandbox.toPath());
+            var ret = command.run(sandbox.toPath());
             assertEquals(0, ret);
             // We have created a directory as intermediate step that should not be there any more
             var intermediateDirectory = new File(sandbox, "test");

--- a/src/test/java/comics/logic/TestUnpack.java
+++ b/src/test/java/comics/logic/TestUnpack.java
@@ -141,7 +141,7 @@ public class TestUnpack {
                 var result = command.run(null);
                 assertNotEquals(0, result);
             });
-            assertTrue(ctx.out().contains("run the command on a non-null directory"));
+            assertTrue(ctx.err().contains("run the command on a non-null directory"));
         });
     }
 

--- a/src/test/resources/uncompressed/something.nfo
+++ b/src/test/resources/uncompressed/something.nfo
@@ -1,0 +1,1 @@
+whatever people write here


### PR DESCRIPTION
- Added prevention of file name repetition in pack and repack commands
- Added cleanup of backup directory after 7 days
- Filtering .nfo files
- Filtering undesired directories added by certain OSs
- Added optional gargabe collector that intends to remove images that do not belong to the comic